### PR TITLE
Invert the colours of Icinga alert boxes

### DIFF
--- a/src/components/IcingaAlert.scss
+++ b/src/components/IcingaAlert.scss
@@ -2,7 +2,7 @@
 
 .IcingaAlert {
   border: 10px solid $grey-2;
-  color: $black;
+  color: $white;
   display: block;
   padding: 10px;
   text-decoration: none;
@@ -30,17 +30,17 @@
 }
 
 .IcingaAlert--critical {
-  border-color: $red;
+  background: $red;
 }
 
 .IcingaAlert--warning {
-  border-color: $orange;
+  background: $orange;
 }
 
 .IcingaAlert--clear {
-  border-color: $green;
+  background: $green;
 }
 
 .IcingaAlert--unknown {
-  border-color: $fuschia;
+  background: $fuschia;
 }

--- a/src/components/IcingaAlert.scss
+++ b/src/components/IcingaAlert.scss
@@ -1,10 +1,9 @@
 @import "assets/govuk-frontend-toolkit.scss";
 
 .IcingaAlert {
-  border: 10px solid $grey-2;
   color: $white;
   display: block;
-  padding: 10px;
+  padding: 20px;
   text-decoration: none;
 }
 


### PR DESCRIPTION
We think it'll be more obvious if these colours are inverted and easier to check at a glance if environments are healthy.